### PR TITLE
Minor fixes for git proxy

### DIFF
--- a/devbox/src/cmdproxy/ProxyServer.scala
+++ b/devbox/src/cmdproxy/ProxyServer.scala
@@ -63,7 +63,11 @@ class ProxyServer(dirMapping: Seq[(os.Path, os.RelPath)], port: Int = ProxyServe
 
     upickle.default.read[Request](in.readLine()) match {
       case Request(dir, args) =>
-        val workingDir = localDir.getOrElse(RelPath(dir), os.home / RelPath(dir))
+        val workingDir = localDir
+          .collect{case (remote, local) if RelPath(dir).startsWith(remote) =>
+            local / RelPath(dir).relativeTo(remote)
+          }
+          .head
 
         // being cautious here and only execute "git" commands
         if (args.headOption.exists((_ == "git"))) {

--- a/launcher/resources/git-shim.py
+++ b/launcher/resources/git-shim.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+from __future__ import print_function
 import socket, os, os.path, sys, json, subprocess
 
 PORT=20280
@@ -63,5 +64,5 @@ s.close()
 
 response = json.loads(reply)
 
-print(response.get("output", "No output received from Git Proxy, something went wrong."))
+print(response.get("output", "No output received from Git Proxy, something went wrong."), end="")
 sys.exit(response.get("exitCode", 0))


### PR DESCRIPTION
- Properly handle host-machine working directory for git commands which are run within a sub-folder of the devbox repository. Previously we were just setting the path to be relative to the home directory, which only works if the host-machine and devbox repositories are in the same place relative to the home folder

- Avoid printing a trailing newline in `git-shim.py`, since the captured output will already have any necessary trailing newlines included

Tested manually, seems to fix the issues I was having