### PR TITLE
Add --sync-ignore to allow further cutting down of repo size

### DIFF
--- a/devbox/common/src/InitialScan.scala
+++ b/devbox/common/src/InitialScan.scala
@@ -2,7 +2,9 @@ package devbox.common
 
 
 object InitialScan {
-  def initialSkippedScan(bases: Seq[os.Path], skippers: Seq[Skipper])
+  def initialSkippedScan(bases: Seq[os.Path],
+                         skippers: Seq[Skipper],
+                         syncIgnore: Option[com.google.re2j.Pattern])
                         (f: (os.Path, os.SubPath, os.StatInfo) => Unit): Unit = {
     for((base, skipper) <- bases.zip(skippers)) {
 
@@ -12,7 +14,9 @@ object InitialScan {
 
       val fileStream = os.walk.stream.attrs(
         base,
-        (p, attrs) => skipper.initialScanIsPathSkipped(base, p.subRelativeTo(base), attrs.isDir)
+        (p, attrs) =>
+          syncIgnore.fold(false)(regex => regex.matches(p.relativeTo(base).toString())) ||
+          skipper.initialScanIsPathSkipped(base, p.subRelativeTo(base), attrs.isDir)
       )
 
       fileStream.foreach { case (p, attrs) =>

--- a/devbox/common/src/Rpc.scala
+++ b/devbox/common/src/Rpc.scala
@@ -13,7 +13,10 @@ object Action{
 
 object Rpc{
   /** Perform a full scan of each root path, including any gitignored files appearing in the cooresponding forceIncludes */
-  case class FullScan(roots: Seq[os.RelPath], forceIncludes: Seq[Seq[os.SubPath]], proxyGit: Boolean) extends Rpc
+  case class FullScan(roots: Seq[os.RelPath],
+                      forceIncludes: Seq[Seq[os.SubPath]],
+                      proxyGit: Boolean,
+                      syncIgnore: Option[String]) extends Rpc
   object FullScan{ implicit val rw: ReadWriter[FullScan] = macroRW }
 
 

--- a/devbox/src/DevboxMain.scala
+++ b/devbox/src/DevboxMain.scala
@@ -24,6 +24,7 @@ object DevboxMain {
                     logFile: Option[os.Path] = None,
                     ignoreStrategy: String = "",
                     readOnlyRemote: String = null,
+                    syncIgnore: String = null,
                     healthCheckInterval: Int = 0,
                     retryInterval: Int = 0,
                     noSync: Boolean = false,
@@ -59,6 +60,11 @@ object DevboxMain {
       "readonly-remote", None,
       "",
       (c, v) => c.copy(readOnlyRemote = v)
+    ),
+    Arg[Config, String](
+      "sync-ignore", None,
+      "",
+      (c, v) => c.copy(syncIgnore = v)
     ),
     Arg[Config, Int](
       "health-check-interval", None,
@@ -172,7 +178,8 @@ object DevboxMain {
             )
           case (path, sig) => sig
         }
-      }
+      },
+      Option(config.syncIgnore)
     )
 
     if (config.proxyGit)

--- a/devbox/src/syncer/AgentReadWriteActor.scala
+++ b/devbox/src/syncer/AgentReadWriteActor.scala
@@ -169,7 +169,7 @@ class AgentReadWriteActor(agent: AgentApi,
     msg match{
       case SyncFiles.Complete() =>
 
-      case SyncFiles.RemoteScan(paths, _, _) =>
+      case SyncFiles.RemoteScan(paths, _, _, _) =>
         logger.info("Scanning directories", paths.mkString("\n"))
 
       case SyncFiles.RpcMsg(rpc) =>
@@ -183,12 +183,12 @@ class AgentReadWriteActor(agent: AgentApi,
   def getRpcFor(msg: SyncFiles.Msg, buf: ByteBuffer): Option[Rpc] = {
     msg match{
       case SyncFiles.Complete() => Some(Rpc.Complete())
-      case SyncFiles.RemoteScan(paths, forceIncludes, proxyGit) =>
+      case SyncFiles.RemoteScan(paths, forceIncludes, proxyGit, syncIgnore) =>
         // convert each PathSet to a Seq, which is what the RPC message expects
         val seqs = for (pathset <- forceIncludes) yield {
           pathset.walk(Seq.empty).map(segs => os.SubPath.apply(segs: IndexedSeq[String])).toVector
         }
-        Some(Rpc.FullScan(paths, seqs, proxyGit))
+        Some(Rpc.FullScan(paths, seqs, proxyGit, syncIgnore))
       case SyncFiles.RpcMsg(rpc) => Some(rpc)
 
       case SyncFiles.SendChunkMsg(src, dest, subPath, chunkIndex, chunkCount) =>

--- a/devbox/src/syncer/SyncFiles.scala
+++ b/devbox/src/syncer/SyncFiles.scala
@@ -11,7 +11,10 @@ object SyncFiles {
   sealed trait Msg
 
   case class Complete() extends Msg
-  case class RemoteScan(paths: Seq[os.RelPath], forceIncludes: Seq[PathSet], proxyGit: Boolean) extends Msg
+  case class RemoteScan(paths: Seq[os.RelPath],
+                        forceIncludes: Seq[PathSet],
+                        proxyGit: Boolean,
+                        syncIgnore: Option[String]) extends Msg
   case class RpcMsg(value: Rpc with PathRpc) extends Msg
 
   case class SendChunkMsg(src: os.Path,

--- a/devbox/src/syncer/Syncer.scala
+++ b/devbox/src/syncer/Syncer.scala
@@ -15,8 +15,16 @@ class Syncer(agent: AgentApi,
              ignoreStrategy: String = "dotgit",
              debounceMillis: Int,
              proxyGit: Boolean,
-             signatureTransformer: (os.SubPath, Sig) => Sig)
+             signatureTransformer: (os.SubPath, Sig) => Sig,
+             syncIgnore: Option[String])
             (implicit ac: castor.Context, logger: SyncLogger) extends AutoCloseable{
+
+
+  val syncIgnoreRegex = syncIgnore.map(com.google.re2j.Pattern.compile(_))
+  pprint.log(syncIgnore)
+  val dummy = "apiproxy/deploy/multitenant/zzz_JSONNET_GENERATED/azure/prod/az-brazilsouth/mt-shard/apiproxy.yaml"
+  pprint.log(syncIgnoreRegex.map(_.matches(dummy)))
+
   println(s"Syncing ${mapping.map{case (from, to) => s"$from:$to"}.mkString(", ")}")
 
   /** Skippers to use on each repository, used by the SkipScan actor and also sent to the remote endpoint */
@@ -40,7 +48,8 @@ class Syncer(agent: AgentApi,
   val skipActor = new SkipScanActor(
     sigActor,
     mapping,
-    skippers
+    skippers,
+    syncIgnoreRegex
   )
 
   val watcher = os.watch.watch(
@@ -64,7 +73,7 @@ class Syncer(agent: AgentApi,
 
     agentActor.send(
       AgentReadWriteActor.Send(
-        SyncFiles.RemoteScan(mapping.map(_._2), allForceIncludes, proxyGit)
+        SyncFiles.RemoteScan(mapping.map(_._2), allForceIncludes, proxyGit, syncIgnore)
       )
     )
     skipActor.send(SkipScanActor.StartScan())


### PR DESCRIPTION
Using this to filter out `/zzz_` files cuts the synced repository down from ~700mb to ~240mb, while still allowing all major workflows I tested