### PR TITLE
Improve reliability of SSH forwarding

### DIFF
--- a/devbox/src/cmdproxy/ProxyServer.scala
+++ b/devbox/src/cmdproxy/ProxyServer.scala
@@ -29,8 +29,9 @@ object Request {
  *
  * Request is one line, terminated with \n: "
  *   {"workingDir":"universe","cmd":["git","status"]}
- * Response:
- *   {"exitCode":0,"output":"bla bla"}
+ *
+ * Response is either a Left(line: String) for lines of output, or Right(exitCode: Int) for
+ * the end of the output stream
  */
 class ProxyServer(dirMapping: Seq[(os.Path, os.RelPath)],
                   port: Int = ProxyServer.DEFAULT_PORT)

--- a/devbox/src/syncer/AgentApi.scala
+++ b/devbox/src/syncer/AgentApi.scala
@@ -13,7 +13,9 @@ trait AgentApi {
 }
 
 class ReliableAgent(prepareWithLogs: (String => Unit) => Boolean,
-                    cmd: Seq[String], cwd: os.Path) extends AgentApi {
+                    cmd: Seq[String],
+                    postConnect: () => Unit,
+                    cwd: os.Path) extends AgentApi {
   var process: os.SubProcess = _
 
   override def start(logPrepOutput: String => Unit): Boolean = {
@@ -21,7 +23,10 @@ class ReliableAgent(prepareWithLogs: (String => Unit) => Boolean,
 
     val prepPassed = prepareWithLogs(logPrepOutput)
 
-    if (prepPassed) process = os.proc(cmd).spawn(cwd = cwd)
+    if (prepPassed) {
+      process = os.proc(cmd).spawn(cwd = cwd)
+      postConnect()
+    }
 
     prepPassed
   }

--- a/devbox/test/src/devbox/DevboxTests.scala
+++ b/devbox/test/src/devbox/DevboxTests.scala
@@ -282,6 +282,7 @@ object DevboxTests extends TestSuite{
           case Some(n) => Seq("--random-kill", n.toString)
           case None => Nil
         }),
+        () => ()/*donothign*/,
         dest
       ),
       Seq(src -> os.rel),

--- a/launcher/resources/git-shim.py
+++ b/launcher/resources/git-shim.py
@@ -52,6 +52,9 @@ socket_file = s.makefile()
 
 for line in socket_file.readlines():
     response = json.loads(line)
+    # In the server protocol, the first item in the array is a tag, where 0
+    # tells us the second item is a line of text, and 1 tells us the second item
+    # is the exit code of the completed command
     if len(response) == 2:
         if response[0] == 0:
             print(response[1])


### PR DESCRIPTION
- Ensure we always re-start the ProxyServer every time after the `ssh -R` connection has been re-established. If we start the ProxyServer before `ssh -R` it doesn't work, and if we have a ProxyServer running from a previous `ssh -R` connection it also doesn't seem to work

- Tweak the `git-shim.py` protocol to allow streaming results: each line is either a `Left(line: String)` or `Right(exitCode: Int)`, serialized to JSON via uPickle's default `Either` structure `[0, ...]` or `[1, ...]`. This allows us to call `git log` in the devbox and have the results stream back without OutOfMemory-ing the git-shim.py or the ProxyServer

The `git-shim.py` changes no longer properly support binary data being returned from the git commands. That's probably OK for now, but we can always drop JSON and go to a binary protocol if we want better support for binary output