### PR TITLE
Copy files into the devbox user home

### DIFF
--- a/devbox/agent/src/DevboxSetupMain.scala
+++ b/devbox/agent/src/DevboxSetupMain.scala
@@ -2,6 +2,8 @@ package devbox.agent
 
 import java.io.ByteArrayOutputStream
 
+import scala.util.control.NonFatal
+
 /**
   * Simple program that allows the devbox launcher to send over multiple
   * commands or files to write all in one go, saving the round trips that
@@ -17,16 +19,23 @@ object DevboxSetupMain {
     val allSetupFilesAndCommands =
       upickle.default.readBinary[Seq[Either[(String, Array[Byte]), String]]](buffer)
 
+    val userName = sys.env.getOrElse("DEVBOX_USER", os.proc("whoami").call().out.trim)
+
     allSetupFilesAndCommands.foreach{
       case Left((destination, bytes)) =>
-        println("Writing file: " + destination)
 
+        // we run as root, so we need to expand ~ to DEVBOX_USER here
         val expandedDestination = destination match{
-          case s"~/$rest" => os.home / os.SubPath(rest)
+          case s"~/$rest" => os.root / "home" / userName / os.SubPath(rest)
           case dest => os.Path(dest)
         }
-        os.write.over(expandedDestination, bytes)
-        os.perms.set(expandedDestination, "rwxrwxrwx")
+        try {
+          os.write.over(expandedDestination, bytes, createFolders = true)
+          os.perms.set(expandedDestination, "rwxrwxrwx")
+        } catch {
+          case NonFatal(e) =>
+            println(s"Error writing file $destination: ${e.getMessage}")
+        }
       case Right(cmd) =>
         println("Running remote command: " + cmd)
         os.proc("bash", "-c", cmd).call()

--- a/launcher/src/EnsureInstanceRunning.scala
+++ b/launcher/src/EnsureInstanceRunning.scala
@@ -450,7 +450,7 @@ case class EnsureInstanceRunning(userName: String = os.proc("whoami").call().out
     os.proc(
       "ssh",
       url,
-      s"HOME=/root sudo java -cp /home/$userName/.devbox/agent.jar devbox.agent.DevboxSetupMain"
+      s"sudo HOME=/root DEVBOX_USER=$userName java -cp /home/$userName/.devbox/agent.jar devbox.agent.DevboxSetupMain"
     ).call(
       mergeErrIntoOut = true,
       stdin = upickle.default.writeBinary(setupFilesAndCommands),

--- a/launcher/src/Main.scala
+++ b/launcher/src/Main.scala
@@ -25,6 +25,10 @@ object Main {
           )
         }
         else {
+          if (!remaining.isEmpty) {
+            println(s"Unknown arguments: ${remaining.mkString(", ")}")
+            System.exit(1)
+          }
           val portFwdArgs =
             if (config.proxyGit)
               Seq("-R", s"${ProxyServer.DEFAULT_PORT}:localhost:${ProxyServer.DEFAULT_PORT}")


### PR DESCRIPTION
The launcher sets up the devbox as root, so we need to expand ~ via the DEVBOX_USER environment variable.

Also, issue an error and exit if there are command line arguments that we do not understand.

Fix #15
