### PR TITLE
Allow multiple concurrent devbox instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ To prepare an assembly jar, ready to be tested and deployed in the universe/
 $ ./mill launcher.assembly
 ```
 
+The result can be found in `out/launcher/assembly/dest/out.jar`
+
 ## Tests
 
 To run all tests (takes a long time):

--- a/devbox/src/cmdproxy/ProxyMain.scala
+++ b/devbox/src/cmdproxy/ProxyMain.scala
@@ -19,6 +19,6 @@ object ProxyMain {
       1024 * 1024
     )
 
-    new ProxyServer(dirMapping = Seq.empty)(logger).start()
+    new ProxyServer(dirMapping = Seq.empty, ProxyServer.DEFAULT_PORT)(logger).start()
   }
 }

--- a/devbox/src/cmdproxy/ProxyServer.scala
+++ b/devbox/src/cmdproxy/ProxyServer.scala
@@ -34,7 +34,7 @@ object Request {
  * the end of the output stream
  */
 class ProxyServer(dirMapping: Seq[(os.Path, os.RelPath)],
-                  port: Int = ProxyServer.DEFAULT_PORT)
+                  port: Int)
                  (implicit logger: FileLogger) {
 
   // this may throw when binding if the socket is used, but for the moment we just assume there is no other

--- a/devbox/src/logger/SyncLogger.scala
+++ b/devbox/src/logger/SyncLogger.scala
@@ -32,7 +32,8 @@ object SyncLogger{
 
   class Impl(val dest: String => os.Path,
              val rotationSize: Long,
-             onClick: => castor.Actor[Unit])
+             onClick: => castor.Actor[Unit],
+             titleOpt: Option[String])
             (implicit ac: castor.Context) extends castor.SimpleActor[Msg] with SyncLogger {
 
     def init() = this.send(Init())
@@ -67,7 +68,7 @@ object SyncLogger{
     val consoleLogger = new ConsoleLogger(dest, rotationSize)
     val statusActor = new StatusActor(
       imageName => IconHandler.icon.setImage(IconHandler.images(imageName)),
-      tooltip => IconHandler.icon.setToolTip(fansi.Str(tooltip).plainText)
+      tooltip => IconHandler.setToolTip(fansi.Str(tooltip).plainText)
     )
 
     def run(msg: Msg) = if (!closed) msg match{
@@ -135,10 +136,12 @@ object SyncLogger{
 
       val icon = new java.awt.TrayIcon(images("blue-sync"))
 
-      icon.setToolTip("Devbox Initializing")
+      setToolTip("Devbox Initializing")
 
       val tray = java.awt.SystemTray.getSystemTray()
 
+      def setToolTip(s: String) =
+        icon.setToolTip(titleOpt.map(_ + "\n").getOrElse("") + s)
 
       icon.addMouseListener(new MouseListener {
         def mouseClicked(e: MouseEvent): Unit = onClick.send(())

--- a/devbox/test/src/devbox/DevboxTestMain.scala
+++ b/devbox/test/src/devbox/DevboxTestMain.scala
@@ -93,7 +93,8 @@ object DevboxTestMain {
             implicit lazy val logger: devbox.logger.SyncLogger.Impl = new devbox.logger.SyncLogger.Impl(
               n => os.pwd / "out" / "scratch" / config.label / s"log$n.txt",
               5 * 1024 * 1024,
-              new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor)
+              new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor),
+              None
             )
             lazy val syncer = instantiateSyncer(
               src, dest,

--- a/devbox/test/src/devbox/DevboxTests.scala
+++ b/devbox/test/src/devbox/DevboxTests.scala
@@ -127,7 +127,8 @@ object DevboxTests extends TestSuite{
       implicit lazy val logger: SyncLogger.Impl = new SyncLogger.Impl(
         n => logFileBase / s"$logFileName$n.$logFileExt",
         5 * 1024 * 1024,
-        new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor)
+        new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor),
+        None
       )
 
       lazy val syncer = instantiateSyncer(
@@ -268,9 +269,9 @@ object DevboxTests extends TestSuite{
                         logger: SyncLogger) = {
 
     val syncer = new Syncer(
-      new ReliableAgent(
-        log => /*do nothing*/true,
-        Seq(
+      new ReliableAgent[Unit](
+        log => /*do nothing*/ Some(()),
+        _ => Seq(
           "java", "-cp",
           System.getenv("AGENT_EXECUTABLE"), "devbox.agent.DevboxAgentMain",
           "--ignore-strategy", ignoreStrategy,


### PR DESCRIPTION
- They have to be started with different --url arguments.

- The local git proxy is now bound to an automatically allocated port which gets mapped to 20280 on the devbox.

- The tray icon tooltip shows the URL so you can identify the individual devbox instances.