### PR TITLE
[PLAT-26020] add tags to devbox volumes

### DIFF
--- a/launcher/src/Instance.scala
+++ b/launcher/src/Instance.scala
@@ -175,6 +175,17 @@ object Instance{
                 .build()
             }:_*
           )
+          .build(),
+        TagSpecification.builder()
+          .resourceType(ResourceType.VOLUME)
+          .tags(
+            tags.map{case (k, v) =>
+              Tag.builder()
+                .key(k)
+                .value(v)
+                .build()
+            }:_*
+          )
           .build()
       )
       .userData(java.util.Base64.getEncoder.encodeToString(userdata.getBytes))


### PR DESCRIPTION
Attach user specified tags to the devbox volume, in addition to instance. This is intended to attach cost tags. Will use https://github.com/databricks/universe/pull/81016 to bump the version number after this makes it in.

Looking for a tentative approval, as I would need to work with security to add permissions before I can complete testing.
This requires volume-related permissions to the role arn:aws:iam::707343435239:policy/devbox-launcher (VolumeId line in the screenshot below is not part of the current permissions)

![image](https://user-images.githubusercontent.com/61990677/105529015-bf1a3800-5cb3-11eb-8f7f-a5d0e49ef0c0.png)

Absent that, I get _software.amazon.awssdk.services.ec2.model.Ec2Exception: You are not authorized to perform this operation_. 

I am also seeking an SOP on how to publish version 0.1.9 once I submit this.