### PR TITLE
[PLAT-27934] Introduce SyncLogger.NoOp for tests

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -86,5 +86,9 @@ object devbox extends DevboxModule{
       "OSLIB_BUNDLE" -> oslibBundle().path.toString,
       "MILL_BUNDLE" -> millBundle().path.toString
     )
+
+    def forkArgs = Seq(
+      "-Djava.awt.headless=true"
+    )
   }
 }

--- a/devbox/src/logger/SyncLogger.scala
+++ b/devbox/src/logger/SyncLogger.scala
@@ -1,7 +1,9 @@
 package devbox.logger
 
 import java.awt.event.{MouseEvent, MouseListener}
+
 import devbox.common.{BaseLogger, Logger, PathSet, Util}
+import os.Path
 trait SyncLogger{
   def init(): Unit
   def close(): Unit
@@ -152,5 +154,31 @@ object SyncLogger{
       })
     }
 
+  }
+
+  class NoOp() (implicit ac: castor.Context) extends castor.SimpleActor[Msg] with SyncLogger {
+    override def run(msg: Msg): Unit = {}
+
+    override def init(): Unit = {}
+
+    override def close(): Unit = {}
+
+    override def apply(tag: String, x: Any): Unit = {}
+
+    override def info(chunks: String*): Unit = {}
+
+    override def error(chunks: String*): Unit = {}
+
+    override def grey(chunks: String*): Unit = {}
+
+    override def progress(chunks: String*): Unit = {}
+
+    override def done(): Unit = {}
+
+    override def syncingFile(chunkMsg: String, subPath: String, suffix: String): Unit = {}
+
+    override def incrementFileTotal(base: Path, subs: PathSet): Unit = {}
+
+    override def filesAndBytes(files: Long, bytes: Long): Unit = {}
   }
 }

--- a/devbox/test/src/devbox/DevboxTestMain.scala
+++ b/devbox/test/src/devbox/DevboxTestMain.scala
@@ -90,12 +90,7 @@ object DevboxTestMain {
           if (config.label == "manual"){
             implicit val ac = new castor.Context.Test(castor.Context.Simple.executionContext, _.printStackTrace())
             val (src, dest, log) = prepareFolders(config.label, config.preserve)
-            implicit lazy val logger: devbox.logger.SyncLogger.Impl = new devbox.logger.SyncLogger.Impl(
-              n => os.pwd / "out" / "scratch" / config.label / s"log$n.txt",
-              5 * 1024 * 1024,
-              new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor),
-              None
-            )
+            implicit lazy val logger: devbox.logger.SyncLogger.NoOp = new devbox.logger.SyncLogger.NoOp()
             lazy val syncer = instantiateSyncer(
               src, dest,
               config.debounceMillis,

--- a/devbox/test/src/devbox/DevboxTests.scala
+++ b/devbox/test/src/devbox/DevboxTests.scala
@@ -124,12 +124,7 @@ object DevboxTests extends TestSuite{
         else ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()),
         _.printStackTrace()
       )
-      implicit lazy val logger: SyncLogger.Impl = new SyncLogger.Impl(
-        n => logFileBase / s"$logFileName$n.$logFileExt",
-        5 * 1024 * 1024,
-        new castor.ProxyActor((_: Unit) => AgentReadWriteActor.ForceRestart(), syncer.agentActor),
-        None
-      )
+      implicit lazy val logger: SyncLogger.NoOp = new SyncLogger.NoOp()
 
       lazy val syncer = instantiateSyncer(
         src, dest, 50,


### PR DESCRIPTION
SyncLogger is responsible for changing the system tray icon (the green icon next to the clock). When running tests on GitHub, there is no X server so we just get a bunch of exceptions like:
```
java.awt.HeadlessException
	at java.awt.TrayIcon.<init>(TrayIcon.java:141)
	at java.awt.TrayIcon.<init>(TrayIcon.java:168)
	at devbox.logger.SyncLogger$Impl$IconHandler$.<init>(SyncLogger.scala:139)
... more stuff ...
```

Let's use a no-op implementation on tests and also run them with `"-Djava.awt.headless=true"` so we get the same behaviour everywhere.