### PR TITLE
[PLAT-27934] Use tmpfs when running GitHub actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,19 +11,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Symlink /dev/shm
+      run: ln -s /dev/shm tmpfs
     - uses: actions/checkout@v2
+      with:
+        path: tmpfs/devbox
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
     - name: Build launcher
       run: ./mill launcher.assembly
+      working-directory: ./tmpfs/devbox
     - name: Build agent
       run: ./mill devbox.agent.assembly
+      working-directory: ./tmpfs/devbox
     - name: Run tests
       run: ./mill devbox.test
+      working-directory: ./tmpfs/devbox
     - name: Upload test logs
       uses: actions/upload-artifact@v2
       with:
         name: testlogs
-        path: out/devbox/test/test/log
+        path: ./tmpfs/devbox/out/devbox/test/test/log


### PR DESCRIPTION
Our tests are currently timing out. I suspect they time out because of heavy filesystem usage, so let's try to use tmpfs to speed things up.

Example run: https://github.com/databricks/devbox/actions/runs/521357070