### PR TITLE
Don't run tests on GH actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,14 +23,14 @@ jobs:
     - name: Build launcher
       run: ./mill launcher.assembly
       working-directory: ./tmpfs/devbox
-    - name: Build agent
-      run: ./mill devbox.agent.assembly
-      working-directory: ./tmpfs/devbox
-    - name: Run tests
-      run: ./mill devbox.test
-      working-directory: ./tmpfs/devbox
-    - name: Upload test logs
-      uses: actions/upload-artifact@v2
-      with:
-        name: testlogs
-        path: ./tmpfs/devbox/out/devbox/test/test/log
+# GitHub actions is struggling to run the tests
+# I believe the problem is because we rely heavily on filesystem notifications
+# and who knows what their container is doing. I wasn't able to repro locally or with Docker.
+#    - name: Run tests
+#      run: ./mill devbox.test
+#      working-directory: ./tmpfs/devbox
+#    - name: Upload test logs
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: testlogs
+#        path: ./tmpfs/devbox/out/devbox/test/test/log

--- a/devbox/test/src/devbox/DevboxTestMain.scala
+++ b/devbox/test/src/devbox/DevboxTestMain.scala
@@ -90,7 +90,10 @@ object DevboxTestMain {
           if (config.label == "manual"){
             implicit val ac = new castor.Context.Test(castor.Context.Simple.executionContext, _.printStackTrace())
             val (src, dest, log) = prepareFolders(config.label, config.preserve)
-            implicit lazy val logger: devbox.logger.SyncLogger.NoOp = new devbox.logger.SyncLogger.NoOp()
+            implicit lazy val logger: devbox.logger.SyncLogger.ConsoleOnly = new devbox.logger.SyncLogger.ConsoleOnly(
+              n => os.pwd / "out" / "scratch" / config.label / s"log$n.txt",
+              5 * 1024 * 1024,
+            )
             lazy val syncer = instantiateSyncer(
               src, dest,
               config.debounceMillis,

--- a/devbox/test/src/devbox/DevboxTests.scala
+++ b/devbox/test/src/devbox/DevboxTests.scala
@@ -124,7 +124,10 @@ object DevboxTests extends TestSuite{
         else ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor()),
         _.printStackTrace()
       )
-      implicit lazy val logger: SyncLogger.NoOp = new SyncLogger.NoOp()
+      implicit lazy val logger: SyncLogger.ConsoleOnly = new devbox.logger.SyncLogger.ConsoleOnly(
+        n => logFileBase / s"$logFileName$n.$logFileExt",
+        5 * 1024 * 1024,
+      )
 
       lazy val syncer = instantiateSyncer(
         src, dest, 50,


### PR DESCRIPTION
I've been investigating what I believe to be a race condition on tests running on GitHub actions.

On the main test loop, we sleep after a git checkout to give room to the filesystem watcher to put events back into the actor system
On GitHub actions, the filesystem watcher is probably much slower and tests fail in all sorts of weird ways.
https://github.com/databricks/devbox/blob/master/devbox/test/src/devbox/DevboxTests.scala#L151-L157

Using a larger timeout seems to improve the tests situation, but some still fail.

The tests also hang after a few failures, due to some file system weirdness as well. One example happens when the agent doesn't sync a directory and then starts to crash loop while trying to sync a file:
```
ArraySeq(Unable to connect to devbox, trying again after 1 seconds)
ArraySeq(Restarting Devbox agent, Attempt #1)
Error: Exception in thread "main" java.nio.file.NoSuchFileException: /home/runner/work/devbox/devbox/out/scratch/simple-git/dest/directory/empty.txt
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:361)
	at os.write$.write(ReadWriteOps.scala:61)
	at os.write$.apply(ReadWriteOps.scala:72)
	at devbox.agent.DevboxAgentMain$.mainLoop(DevboxAgentMain.scala:175)
	at devbox.agent.DevboxAgentMain$.main(DevboxAgentMain.scala:119)
	at devbox.agent.DevboxAgentMain.main(DevboxAgentMain.scala)
ArraySeq(Unable to connect to devbox, trying again after 1 seconds)
```

This started to get way too complex and given the volume of work done on this repo, I decided to disable it. We can still run the tests locally.

I'm also adding better logging if we come to this in the future.
