### PR TITLE
Action to create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        default: '0.0.0'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build
+        run: ./mill launcher.assembly
+      - name: Calculate SHA-1
+        id: caculate_sha1
+        run: echo "::set-output name=sha1::$(sha1sum ./out/launcher/assembly/dest/out.jar | cut -d " " -f 1)"
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: Release ${{ github.event.inputs.version }} (sha ${{ steps.caculate_sha1.outputs.sha1 }})
+          draft: false
+          prerelease: false
+      - name: Upload devbox.jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: ./out/launcher/assembly/dest/out.jar
+            asset_name: devbox.jar


### PR DESCRIPTION
This should give us the ability to create the new release on the press on a button on the "Actions" tab.

A few caveats:
- We still need to enter the version number manually
- We still need to sync the new version on the universe repo manually (we can probably come up with a periodic bump in the future)