### PR TITLE
Update README for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ $ ./mill devbox.test
 ```
 $ ./mill -i devbox.repl
 ```
+
+## Release
+
+There is a [Github Action](https://github.com/databricks/devbox/actions?query=workflow%3ARelease) to release Devbox.
+
+Just run the workflow on the target branch (usually master) with the new version number and check
+the [releases](https://github.com/databricks/devbox/releases) page


### PR DESCRIPTION
As described on #32 , we now can create releases using github actions.

Example release: https://github.com/databricks/devbox/releases/tag/0.0.0

The sha-1 of the jar is part of the release description. I tested and it works on universe:
```
# gabriel.russo at C02D65HQMD6R in ~/universe [17:53:32]
$ bin/devbox
Downloading Devbox 0.0.0 from https://github.com/databricks/devbox/releases/download/0.0.0/devbox.jar
```