### PR TITLE
[PLAT-28297] Add a cli option to specify compression

### DIFF
--- a/devbox/agent/src/DevboxAgentMain.scala
+++ b/devbox/agent/src/DevboxAgentMain.scala
@@ -13,6 +13,7 @@ import devbox.common._
 import devbox.common.Cli
 import devbox.common.Cli.Arg
 import devbox.common.Cli.pathScoptRead
+import devbox.common.CompressionMode
 import os.Path
 
 object DevboxAgentMain {
@@ -190,11 +191,15 @@ object DevboxAgentMain {
           }
           client.writeMsg(Response.Ack())
 
-        case Rpc.WriteChunk(root, path, offset, data) =>
+        case Rpc.WriteChunk(root, path, offset, data, compressed) =>
           val p = wd / root / path
 
+          val bytes = compressed match {
+            case CompressionMode.gzip => Util.gunzip(data.value)
+            case _ => data.value
+          }
           withWritable(p){
-            os.write.write(p, data.value, Seq(StandardOpenOption.WRITE), 0, offset)
+            os.write.write(p, bytes, Seq(StandardOpenOption.WRITE), 0, offset)
           }
           client.writeMsg(Response.Ack())
 

--- a/devbox/common/src/CompressionMode.scala
+++ b/devbox/common/src/CompressionMode.scala
@@ -1,0 +1,12 @@
+package devbox.common
+
+import upickle.default.{ReadWriter, readwriter}
+
+object CompressionMode extends Enumeration {
+  type CompressionMode = Value
+  val gzip, ssh, none = Value
+
+  implicit val rw: ReadWriter[CompressionMode] = readwriter[Int].bimap[CompressionMode](_.id, apply(_))
+}
+
+

--- a/devbox/common/src/Rpc.scala
+++ b/devbox/common/src/Rpc.scala
@@ -33,7 +33,7 @@ object Rpc{
   case class PutLink(root: os.RelPath, path: os.SubPath, dest: String) extends Rpc with PathRpc with Action
   object PutLink{ implicit val rw: ReadWriter[PutLink] = macroRW }
 
-  case class WriteChunk(root: os.RelPath, path: os.SubPath, offset: Long, data: Bytes) extends Rpc
+  case class WriteChunk(root: os.RelPath, path: os.SubPath, offset: Long, data: Bytes, compression: CompressionMode.Value) extends Rpc
   object WriteChunk{ implicit val rw: ReadWriter[WriteChunk] = macroRW }
 
   case class SetSize(root: os.RelPath, path: os.SubPath, offset: Long) extends Rpc with PathRpc with Action

--- a/devbox/src/DevboxMain.scala
+++ b/devbox/src/DevboxMain.scala
@@ -28,7 +28,8 @@ object DevboxMain {
                     healthCheckInterval: Int = 0,
                     retryInterval: Int = 0,
                     noSync: Boolean = false,
-                    proxyGit: Boolean = true)
+                    proxyGit: Boolean = true,
+                    compression: CompressionMode.Value = CompressionMode.ssh)
 
   val signature = Seq(
     Arg[Config, String](
@@ -80,6 +81,11 @@ object DevboxMain {
       "proxy-git-commands", None,
       "Don't sync .git directories and proxy git commands back to the laptop",
       (c, v) => c.copy(proxyGit = v)
+    ),
+    Arg[Config, String](
+      "compression", None,
+      s"Enables compression. Possible values are ${CompressionMode.values.mkString(",")}. Defaults to ssh.",
+      (c, v) => c.copy(compression = CompressionMode.withName(v))
     ),
 
   )
@@ -211,7 +217,8 @@ object DevboxMain {
           case (path, sig) => sig
         }
       },
-      Option(config.syncIgnore)
+      Option(config.syncIgnore),
+      config.compression
     )
 
     Util.autoclose(syncer){syncer =>

--- a/devbox/test/src/devbox/DevboxTests.scala
+++ b/devbox/test/src/devbox/DevboxTests.scala
@@ -33,6 +33,12 @@ object DevboxTests extends TestSuite{
       test("git") - testCase(1, ignoreStrategy = "")
       test("restart") - testCase(1, restartInterval = Some(1))
       test("reconnect") - testCase(1, randomKillInterval = Some(50))
+
+      // Test different compression modes
+      test("compression-gzip") - testCase(1, compression = CompressionMode.gzip)
+      // ssh compression here doesn't do anything since we don't ssh anywhere.
+      test("compression-ssh") - testCase(1, compression = CompressionMode.ssh)
+      test("compression-none") - testCase(1, compression = CompressionMode.none)
     }
 
     test("oslib") {
@@ -89,7 +95,8 @@ object DevboxTests extends TestSuite{
                ignoreStrategy: String = "dotgit",
                restartInterval: Option[Int] = None,
                randomKillInterval: Option[Int] = None,
-               parallel: Boolean = true)
+               parallel: Boolean = true,
+               compression: CompressionMode.Value = CompressionMode.none)
               (implicit tp: TestPath) = {
     walkValidate(
       tp.value.mkString("-"),
@@ -99,7 +106,8 @@ object DevboxTests extends TestSuite{
       ignoreStrategy = ignoreStrategy,
       restartInterval = restartInterval,
       randomKillInterval = randomKillInterval,
-      parallel = parallel
+      parallel = parallel,
+      compression = compression,
     )
   }
   def walkValidate(label: String,
@@ -110,7 +118,8 @@ object DevboxTests extends TestSuite{
                    ignoreStrategy: String = "dotgit",
                    restartInterval: Option[Int] = None,
                    randomKillInterval: Option[Int] = None,
-                   parallel: Boolean = true) = {
+                   parallel: Boolean = true,
+                   compression: CompressionMode.Value = CompressionMode.none) = {
 
     val (src, dest, log, commits, commitsIndicesToCheck, repo) =
       initializeWalk(label, uri, validateInterval, commitIndicesToCheck0)
@@ -134,7 +143,8 @@ object DevboxTests extends TestSuite{
         ignoreStrategy,
         exitOnError = true,
         signatureMapping = (_, sig) => sig,
-        randomKill = randomKillInterval
+        randomKill = randomKillInterval,
+        compression = compression,
       )
 
       (logger, ac, syncer)
@@ -262,7 +272,8 @@ object DevboxTests extends TestSuite{
                         exitOnError: Boolean,
                         signatureMapping: (os.SubPath, Sig) => Sig,
                         healthCheckInterval: Int = 0,
-                        randomKill: Option[Int] = None)
+                        randomKill: Option[Int] = None,
+                        compression: CompressionMode.Value = CompressionMode.none)
                        (implicit ac: castor.Context,
                         logger: SyncLogger) = {
 
@@ -288,7 +299,8 @@ object DevboxTests extends TestSuite{
       debounceMillis,
       proxyGit = false,
       signatureTransformer = signatureMapping,
-      syncIgnore = None
+      syncIgnore = None,
+      compression = compression
     )
     syncer
   }

--- a/launcher/src/Main.scala
+++ b/launcher/src/Main.scala
@@ -3,6 +3,7 @@ package launcher
 import cmdproxy.ProxyServer
 import devbox.DevboxMain
 import devbox.common.Cli
+import devbox.common.CompressionMode
 
 object Main {
   def main(args: Array[String]): Unit = {
@@ -60,7 +61,8 @@ object Main {
                 prepResult.exitCode == 0
             },
             { (port: Option[Int]) => Seq(
-                "ssh", "-C",
+                "ssh",
+                "-o", s"Compression=${if (config.compression == CompressionMode.ssh) "yes" else "no"}",
                 "-o", "ExitOnForwardFailure=yes",
                 "-o", "ServerAliveInterval=4",
                 "-o", "ServerAliveCountMax=4"


### PR DESCRIPTION
Adds a CLI option to specify how to compress the data we send. Current options are:
- ssh: done on the ssh layer
- gzip: we compress each file chunk individually
- none: no compression

I'm keeping those into an enum, so we can add more compression modes if we want to. The default is ssh, to keep existing behaviour.

See more on https://docs.google.com/document/d/1lRx-4JIAzowBMELlw34oaSG68fyQCLpDQ7MVaIV-s3o/edit#

## Tests

Added some unit tests:
```
# gabriel.russo at C02D65HQMD6R in ~/devbox [13:07:19]
$ ./mill devbox.test "devbox.DevboxTests.simple.{compression-gzip,compression-ssh,compression-none}"
```

Plus also tested running devbox with different options (by tweaking `universe/devbox/sync`):
---
with `--compression ssh`:
```
# gabriel.russo at C02D65HQMD6R in ~/universe [13:06:11]
$ bin/devbox
Syncing /Users/gabriel.russo/universe:universe
Compression mode: ssh
... more stuff ...
``` 

see that the spawned ssh process uses compression:
```
# gabriel.russo at C02D65HQMD6R in ~/devbox [13:06:23]
$ ps -ax | grep ssh

 6877 ttys004    0:00.07 ssh -o Compression=yes -o ExitOnForwardFailure=yes -o ServerAliveInterval=4 -o ServerAliveCountMax=4 -R 20280:localhost:50751 devbox.databricks.com java -cp ~/.devbox/agent.jar devbox.agent.DevboxAgentMain --log-path ~/.devbox/log.txt --ignore-strategy gitignore --proxy-git-commands true
 ```
--- 
with `--compression gzip`:
```
# gabriel.russo at C02D65HQMD6R in ~/universe [13:13:08]
$ bin/devbox
Syncing /Users/gabriel.russo/universe:universe
Compression mode: gzip
```

see that the ssh process does not use compression:
```
# gabriel.russo at C02D65HQMD6R in ~/devbox [13:07:19]
$ ps -ax | grep ssh

 7311 ttys004    0:00.02 ssh -o Compression=no -o ExitOnForwardFailure=yes -o ServerAliveInterval=4 -o ServerAliveCountMax=4 -R 20280:localhost:50882 devbox.databricks.com java -cp ~/.devbox/agent.jar devbox.agent.DevboxAgentMain --log-path ~/.devbox/log.txt --ignore-strategy gitignore --proxy-git-commands true
 ```
 
 in order to verify if traffic was actually being compressed, I used [Wireshark](https://www.wireshark.org/) to monitor my network traffic.


