### PR TITLE
Git Proxy - Handle UTF-8 output in all environments

### DIFF
--- a/launcher/resources/git-shim.py
+++ b/launcher/resources/git-shim.py
@@ -60,7 +60,7 @@ for line in socket_file.readlines():
     # is the exit code of the completed command
     if len(response) == 2:
         if response[0] == 0:
-            print(response[1])
+            print(response[1].encode('utf-8'))
         elif response[0] == 1:
             sys.exit(response[1])
         else:


### PR DESCRIPTION
Python auto-detects the default string encoding based on several environment variables:
```
LANG=C.UTF-8
LC_CTYPE=en_US.UTF-8
```
These are set by default in shells Devbox, and thus the encoding used by default is UTF-8. However, when invoking the git-shim from a shell where these variables are not set or as a subprocess (like from the test-shard CLI) - the default encoding is ASCII. This results in the following error whenever UTF-8 is present in the output of any command (usually a diff)

```
UnicodeEncodeError: 'ascii' codec can't encode characters in position <x>-<y>: ordinal not in range(128)
```

This PR fixes the issue by explicitly setting the encoding of the printed output to UTF-8 - so we don't need to rely on it being properly set in the environment or by callers.